### PR TITLE
Flutter 1.26.0-12.0.pre

### DIFF
--- a/lib/refresh/pull_to_refresh/src/smart_refresher.dart
+++ b/lib/refresh/pull_to_refresh/src/smart_refresher.dart
@@ -1000,7 +1000,7 @@ class RefreshConfiguration extends InheritedWidget {
             RefreshConfiguration.of(context).shouldFooterFollowWhenNotFull;
 
   static RefreshConfiguration of(BuildContext context) {
-    return context.inheritFromWidgetOfExactType(RefreshConfiguration);
+    return context.dependOnInheritedWidgetOfExactType(aspect:RefreshConfiguration);
   }
 
   @override


### PR DESCRIPTION
horizontal_data_table-2.1.0+1/lib/refresh/pull_to_refresh/src/smart_refresher.dart(1003,20): error G76A9B1F6: The method 'inheritFromWidgetOfExactType' isn't defined for the class 'BuildContext'

https://blog.csdn.net/weixin_39983601/article/details/112990720