### PR TITLE
Fix: scrollbar style null pt exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.5.1] [2.5.1-beta] - 20210303
+* Fix: scrollbar style null issue
+
 ## [2.5.0] - 20210228
 * Update: disabled Scrollbar thumb color cutomization
 

--- a/lib/scroll/custom_scroll_bar.dart
+++ b/lib/scroll/custom_scroll_bar.dart
@@ -20,19 +20,19 @@ class CustomScrollBar extends StatelessWidget {
     // if (this.scrollbarStyle?.thumbColor != null) {
     //   return RawScrollbar(
     //     controller: this.controller,
-    //     isAlwaysShown: this.scrollbarStyle.isAlwaysShown,
-    //     thickness: this.scrollbarStyle.thickness,
-    //     radius: this.scrollbarStyle.radius,
-    //     thumbColor: this.scrollbarStyle.thumbColor,
+    //     isAlwaysShown: this.scrollbarStyle?.isAlwaysShown ?? false,
+    //     thickness: this.scrollbarStyle?.thickness,
+    //     radius: this.scrollbarStyle?.radius,
+    //     thumbColor: this.scrollbarStyle?.thumbColor,
     //     child: this.child,
     //   );
     // }
 
     return Scrollbar(
       controller: this.controller,
-      isAlwaysShown: this.scrollbarStyle.isAlwaysShown,
-      thickness: this.scrollbarStyle.thickness,
-      radius: this.scrollbarStyle.radius,
+      isAlwaysShown: this.scrollbarStyle?.isAlwaysShown ?? false,
+      thickness: this.scrollbarStyle?.thickness,
+      radius: this.scrollbarStyle?.radius,
       child: this.child,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: horizontal_data_table
 description: A horizontal data table with a fixed column on left handside.
-version: 2.5.0
+version: 2.5.1
 author: May Lau<may.lau.dev@gmail.com>
 homepage: https://github.com/MayLau-CbL/flutter_horizontal_data_table
 


### PR DESCRIPTION
This PR updated:
1. added null-checker for the null scrollbarstyle obj

Resolves: https://github.com/MayLau-CbL/flutter_horizontal_data_table/issues/36