### PR TITLE
Always show the scrollbar on the right hand size on the screen

### DIFF
--- a/lib/delegate/list_view_layout_delegate.dart
+++ b/lib/delegate/list_view_layout_delegate.dart
@@ -26,7 +26,7 @@ class ListViewLayoutDelegate extends MultiChildLayoutDelegate {
     }
 
     if (hasChild(ListViewLayout.Divider)) {
-      layoutChild(
+      dividerSize = layoutChild(
         ListViewLayout.Divider,
         BoxConstraints(
           maxWidth: this.widgetWidth,

--- a/lib/horizontal_data_table.dart
+++ b/lib/horizontal_data_table.dart
@@ -283,29 +283,33 @@ class _HorizontalDataTableState extends State<HorizontalDataTable> {
           child: CustomScrollBar(
             controller: this._rightHorizontalScrollController,
             scrollbarStyle: widget.horizontalScrollbarStyle,
-            child: SingleChildScrollView(
-              physics: widget.scrollPhysics,
-              controller: _rightHorizontalScrollController,
-              child: Container(
-                color: widget.rightHandSideColBackgroundColor,
-                child: _getFixedHeaderScrollColumn(
-                  height: height,
-                  listViewWidth: widget.rightHandSideColumnWidth,
-                  header: Row(
-                      children:
-                          widget.headerWidgets?.sublist(1).toList() ?? []),
-                  listView: _getScrollColumn(
-                    CustomScrollBar(
-                        controller: this._rightHandSideListViewScrollController,
-                        scrollbarStyle: widget.verticalScrollbarStyle,
-                        child: _getRightHandSideListView()),
-                    this._rightHandSideListViewScrollController,
-                    rightScrollControllerLabel,
+            child: CustomScrollBar(
+              scrollNotificationPredicate: (notification) {
+                return notification.depth == 1;
+              },
+              controller: this._rightHandSideListViewScrollController,
+              scrollbarStyle: widget.verticalScrollbarStyle,
+              child: SingleChildScrollView(
+                physics: widget.scrollPhysics,
+                controller: _rightHorizontalScrollController,
+                child: Container(
+                  color: widget.rightHandSideColBackgroundColor,
+                  child: _getFixedHeaderScrollColumn(
+                    height: height,
+                    listViewWidth: widget.rightHandSideColumnWidth,
+                    header: Row(
+                        children:
+                            widget.headerWidgets?.sublist(1).toList() ?? []),
+                    listView: _getScrollColumn(
+                      _getRightHandSideListView(),
+                      this._rightHandSideListViewScrollController,
+                      rightScrollControllerLabel,
+                    ),
                   ),
+                  width: widget.rightHandSideColumnWidth,
                 ),
-                width: widget.rightHandSideColumnWidth,
+                scrollDirection: Axis.horizontal,
               ),
-              scrollDirection: Axis.horizontal,
             ),
           ),
         ),

--- a/lib/scroll/custom_scroll_bar.dart
+++ b/lib/scroll/custom_scroll_bar.dart
@@ -6,16 +6,22 @@ class CustomScrollBar extends StatelessWidget {
   final ScrollController controller;
   final ScrollbarStyle? scrollbarStyle;
   final Widget child;
+  final ScrollNotificationPredicate? scrollNotificationPredicate;
 
   const CustomScrollBar({
     Key? key,
     required this.controller,
     this.scrollbarStyle,
     required this.child,
+    this.scrollNotificationPredicate,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    ScrollNotificationPredicate snp = scrollNotificationPredicate ??
+        (scrollNotification) {
+          return scrollNotification.depth == 0;
+        };
     if (this.scrollbarStyle?.thumbColor != null) {
       return RawScrollbar(
         controller: this.controller,
@@ -23,6 +29,7 @@ class CustomScrollBar extends StatelessWidget {
         thickness: this.scrollbarStyle?.thickness,
         radius: this.scrollbarStyle?.radius,
         thumbColor: this.scrollbarStyle?.thumbColor,
+        notificationPredicate: snp,
         child: this.child,
       );
     }
@@ -32,6 +39,7 @@ class CustomScrollBar extends StatelessWidget {
       isAlwaysShown: this.scrollbarStyle?.isAlwaysShown ?? false,
       thickness: this.scrollbarStyle?.thickness,
       radius: this.scrollbarStyle?.radius,
+      notificationPredicate: snp,
       child: this.child,
     );
   }

--- a/lib/scroll/custom_scroll_bar.dart
+++ b/lib/scroll/custom_scroll_bar.dart
@@ -18,10 +18,8 @@ class CustomScrollBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    ScrollNotificationPredicate snp = scrollNotificationPredicate ??
-        (scrollNotification) {
-          return scrollNotification.depth == 0;
-        };
+    ScrollNotificationPredicate snp =
+        scrollNotificationPredicate ?? defaultScrollNotificationPredicate;
     if (this.scrollbarStyle?.thumbColor != null) {
       return RawScrollbar(
         controller: this.controller,


### PR DESCRIPTION
On flutter web if the right side scrollbar will only show if the user scrolls all the way to the right side. If both the width and height dimensions are offscreen. This fix will always show both scrollbars on screen.

To reproduce:
1. Make a table with data that is too big for the screen both width and height
2. Scroll the height of the table noticed the vertical scroll bar doesn't show.
3. To see the vertical scroll bar scroll all the way to the right 