### PR TITLE
Set dividerSize in the layout calculation

### DIFF
--- a/lib/delegate/list_view_layout_delegate.dart
+++ b/lib/delegate/list_view_layout_delegate.dart
@@ -26,7 +26,7 @@ class ListViewLayoutDelegate extends MultiChildLayoutDelegate {
     }
 
     if (hasChild(ListViewLayout.Divider)) {
-      layoutChild(
+      dividerSize = layoutChild(
         ListViewLayout.Divider,
         BoxConstraints(
           maxWidth: this.widgetWidth,


### PR DESCRIPTION
Issue:
Missing the divider between the header row and list view

Fix:
Update the dividerSize var