### PR TITLE
Update: vertical scroll logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.4.0] - 20210605
+* Update: Refresh Status export
+* Update: vertical scroll sync logic when pull to refresh is on
+* Update: README.md supported refresh header description
+
 ## [3.3.0] - 20210509
 * Update: separated right header and listview horizontal scroll
 * Add: horizontal scroll physics field for right horizontal scroll

--- a/README.md
+++ b/README.md
@@ -88,14 +88,13 @@ HorizontalDataTable(
       
 ```
 1. refreshIndicator is the header widget when pull to refresh. 
-    Available refreshIndicator:
+    Supported refreshIndicator:
       1. ClassicHeader
       2. WaterDropHeader
-      3. CustomHeader
-      4. LinkHeader
-      5. MaterialClassicHeader
-      6. BezierHeader
+      3. CustomHeader         
+      4. BezierHeader
 
+    Basically single level header with a certain height while refreshing. For the on-top header is currently not supported.
     Since refreshIndicator is a Widget type field, you may customize yourself on the header, but you must set the height of the header. The detail usage you may reference to the [pull-to-refresh](https://pub.dev/packages/pull_to_refresh) package.
 2. refreshIndicatorHeight is the height of the refreshIndicator. Default is set to 60.
 3. onRefresh is the callback from the refresh action.     

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,7 +33,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.3.0"
+    version: "3.4.0"
   meta:
     dependency: transitive
     description:

--- a/lib/horizontal_data_table.dart
+++ b/lib/horizontal_data_table.dart
@@ -13,6 +13,7 @@ export 'package:horizontal_data_table/refresh/pull_to_refresh/src/indicator/cust
 export 'package:horizontal_data_table/refresh/pull_to_refresh/src/indicator/link_indicator.dart';
 export 'package:horizontal_data_table/refresh/pull_to_refresh/src/indicator/material_indicator.dart';
 export 'package:horizontal_data_table/refresh/pull_to_refresh/src/indicator/bezier_indicator.dart';
+export 'package:horizontal_data_table/refresh/pull_to_refresh/src/smart_refresher.dart';
 
 ///Main File
 import 'package:flutter/material.dart';

--- a/lib/scroll/sync_scroll_controller_manager.dart
+++ b/lib/scroll/sync_scroll_controller_manager.dart
@@ -18,7 +18,6 @@ class SyncScrollControllerManager {
   ///Refresh related
   RefreshController? _refreshController;
   double _refreshIndicatorHeight = 0.0;
-  double _cacheScrollOffset = 0.0;
 
   void registerScrollController(ScrollController controller) {
     _registeredScrollControllers.add(controller);
@@ -81,42 +80,54 @@ class SyncScrollControllerManager {
 
   void _syncLeftListViewScrollVontroller(
       ScrollController _scrollingController, ScrollController controller) {
-    switch (_refreshController?.headerStatus) {
-      case RefreshStatus.canRefresh:
-        {
-          if (_cacheScrollOffset < _scrollingController.offset) {
+    if (_refreshController?.headerStatus != null) {
+      switch (_refreshController?.headerStatus) {
+        case RefreshStatus.refreshing:
+          {
             controller.jumpTo(_refreshIndicatorHeight * -1);
-            return;
-          } else {
-            _cacheScrollOffset = _scrollingController.offset;
+            break;
           }
-          break;
-        }
-      case RefreshStatus.refreshing:
-        {
-          return;
-        }
-      default:
-        {
-          _cacheScrollOffset = 0.0;
-          break;
-        }
+        default:
+          {
+            if (_scrollingController.offset < (_refreshIndicatorHeight * -1)) {
+              controller.jumpTo(_refreshIndicatorHeight * -1);
+            } else {
+              controller.jumpTo(_scrollingController.offset);
+            }
+            break;
+          }
+      }
+    } else {
+      controller.jumpTo(_scrollingController.offset);
     }
-    controller.jumpTo(_scrollingController.offset);
   }
 
   void _syncRightListViewScrollVontroller(
       ScrollController _scrollingController, ScrollController controller) {
-    if (!_scrollingController.position.outOfRange) {
-      controller.jumpTo(_scrollingController.offset);
-    } else {
-      if (_scrollingController.offset <= 0.0) {
-        _scrollingController
-            .jumpTo(_scrollingController.position.minScrollExtent);
-      } else {
-        _scrollingController
-            .jumpTo(_scrollingController.position.maxScrollExtent);
+    if (_refreshController?.headerStatus != null) {
+      switch (_refreshController?.headerStatus) {
+        case RefreshStatus.idle:
+          {
+            if (!_scrollingController.position.outOfRange) {
+              controller.jumpTo(_scrollingController.offset);
+            } else {
+              if (_scrollingController.offset <= 0.0) {
+                _scrollingController
+                    .jumpTo(_scrollingController.position.minScrollExtent);
+              } else {
+                _scrollingController
+                    .jumpTo(_scrollingController.position.maxScrollExtent);
+              }
+            }
+            break;
+          }
+        default:
+          {
+            break;
+          }
       }
+    } else {
+      controller.jumpTo(_scrollingController.offset);
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: horizontal_data_table
 description: A horizontal data table with a fixed column on left handside.
-version: 3.3.0
+version: 3.4.0
 author: May Lau<may.lau.dev@gmail.com>
 homepage: https://github.com/MayLau-CbL/flutter_horizontal_data_table
 


### PR DESCRIPTION
This PR updated:
1. updated vertical scroll sync logic
2. enabled RefreshStatus export
3. updated README.md and version

Note: It is known that the scroll on the left and right is not exact the same offset all the time while canRefresh state and even normal scroll may have slightly difference as the sync is relied on the scroll notification. This PR aims to soften the issue.

Resolves: #49 