### PR TITLE
Fix: check for axis match in notificationPredicate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.colorTheme": "Abyss"
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -40,7 +40,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   nested:
     dependency: transitive
     description:

--- a/lib/horizontal_data_table.dart
+++ b/lib/horizontal_data_table.dart
@@ -436,6 +436,22 @@ class _HorizontalDataTableState extends State<HorizontalDataTable> {
             child: CustomScrollBar(
               controller: this._rightHorizontalScrollController,
               scrollbarStyle: widget.horizontalScrollbarStyle,
+              notificationPredicate: (notification) {
+                // For some reason, on  _web only_, the scrollbar catches
+                // notifications from a vertical scrollable with depth: 0.
+                // This causes issues with the horizontal scrollbar disappearing
+                // as soon as vertical scrolling starts, and not obeying the fade
+                // logic or `isShownAlways` styling.
+                //
+                // No idea what the source is. As a workaround, we can just
+                // check the axis of the source scrollable.
+                if (notification.depth == 0 &&
+                    notification.metrics.axis == Axis.horizontal) {
+                  return true;
+                }
+
+                return false;
+              },
               child: NotificationListener<ScrollNotification>(
                 onNotification: (ScrollNotification scrollInfo) {
                   _syncHorizontalScrollControllerManager?.processNotification(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   nested:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
This addresses #59.

This is more of a workaround than a fix. I wasn't able to figure out the source of the scroll notifications (see comment in code), so the best I could figure out was how to ignore them.