### PR TITLE
Fix/warning after flutter 2.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.6.2] - 20220501
+* Update: example android project for 2.10.5 flutter version
+* Remove: uneccessary import of pull to refresh
+* Fix: minor comment typo
+
 ## [3.6.1+1] - 20220201
 * Remove: unused import in pull to refresh lib
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.0'
     repositories {
         google()
         jcenter()

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         jcenter()

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,7 +33,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.6.1+1"
+    version: "3.6.2"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:

--- a/lib/horizontal_data_table.dart
+++ b/lib/horizontal_data_table.dart
@@ -1,4 +1,4 @@
-///Exxport File
+///Export File
 
 ///Scrollbar Style
 export 'package:horizontal_data_table/scroll/scroll_bar_style.dart';
@@ -77,16 +77,16 @@ class HorizontalDataTable extends StatefulWidget {
   final Color leftHandSideColBackgroundColor;
   final Color rightHandSideColBackgroundColor;
 
-  ///Vertical scroll controller, expose for allowing maunally jump to specific offset position. Please aware this may conflict with the pull to refresh action.
+  ///Vertical scroll controller, expose for allowing manually jump to specific offset position. Please aware this may conflict with the pull to refresh action.
   final ScrollController? verticalScrollController;
 
-  ///Horizontal scroll controller, expose for allowing maunally jump to specific offset position.
+  ///Horizontal scroll controller, expose for allowing manually jump to specific offset position.
   final ScrollController? horizontalScrollController;
 
-  ///Vertical Scrollbar Style. Default the scrollbar is using that platform's sysmtem setting.
+  ///Vertical Scrollbar Style. Default the scrollbar is using that platform's system setting.
   final ScrollbarStyle? verticalScrollbarStyle;
 
-  ///Horizontal Scrollbar Style. Default the scrollbar is using that platform's sysmtem setting.
+  ///Horizontal Scrollbar Style. Default the scrollbar is using that platform's system setting.
   final ScrollbarStyle? horizontalScrollbarStyle;
 
   ///Flag to indicate whether enable the pull_to_refresh function
@@ -124,7 +124,7 @@ class HorizontalDataTable extends StatefulWidget {
   ///Horizontal Scroll physics of the data table
   final ScrollPhysics? horizontalScrollPhysics;
 
-  ///This is a wrapper controller for limilating using the available refresh and load new data controller function. Currently only refresh and load fail and complete are implemented.
+  ///This is a wrapper controller for limiting using the available refresh and load new data controller function. Currently only refresh and load fail and complete are implemented.
   final HDTRefreshController? htdRefreshController;
 
   const HorizontalDataTable({

--- a/lib/refresh/pull_to_refresh/src/indicator/classic_indicator.dart
+++ b/lib/refresh/pull_to_refresh/src/indicator/classic_indicator.dart
@@ -6,10 +6,7 @@
 
 import 'package:flutter/material.dart'
     hide RefreshIndicator, RefreshIndicatorState;
-import 'package:flutter/widgets.dart';
 import '../../pull_to_refresh.dart';
-import '../internals/indicator_wrap.dart';
-import '../smart_refresher.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 

--- a/lib/refresh/pull_to_refresh/src/indicator/material_indicator.dart
+++ b/lib/refresh/pull_to_refresh/src/indicator/material_indicator.dart
@@ -4,10 +4,8 @@
  * Time: 2019/5/19 下午9:23
  */
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart'
     hide RefreshIndicator, RefreshIndicatorState;
-import 'package:flutter/widgets.dart';
 import '../internals/indicator_wrap.dart';
 import '../smart_refresher.dart';
 

--- a/lib/refresh/pull_to_refresh/src/indicator/twolevel_indicator.dart
+++ b/lib/refresh/pull_to_refresh/src/indicator/twolevel_indicator.dart
@@ -5,8 +5,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 import 'classic_indicator.dart';
 import '../smart_refresher.dart';
 

--- a/lib/refresh/pull_to_refresh/src/indicator/waterdrop_header.dart
+++ b/lib/refresh/pull_to_refresh/src/indicator/waterdrop_header.dart
@@ -7,12 +7,9 @@
 import 'dart:async';
 import 'package:flutter/material.dart'
     hide RefreshIndicatorState, RefreshIndicator;
-import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
 import '../../pull_to_refresh.dart';
-import '../internals/indicator_wrap.dart';
 import 'package:flutter/cupertino.dart';
-import '../smart_refresher.dart';
 
 /// QQ ios refresh  header effect
 class WaterDropHeader extends RefreshIndicator {

--- a/lib/refresh/pull_to_refresh/src/internals/refresh_localizations.dart
+++ b/lib/refresh/pull_to_refresh/src/internals/refresh_localizations.dart
@@ -6,7 +6,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 /// Implementation of localized strings for the [ClassicHeader],[ClassicFooter],[TwoLevelHeader]
 ///

--- a/lib/refresh/pull_to_refresh/src/smart_refresher.dart
+++ b/lib/refresh/pull_to_refresh/src/smart_refresher.dart
@@ -10,10 +10,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
 import '../pull_to_refresh.dart';
 import '../src/internals/slivers.dart';
-import 'internals/indicator_wrap.dart';
-import 'internals/refresh_physics.dart';
-import 'indicator/classic_indicator.dart';
-import 'indicator/material_indicator.dart';
 
 // ignore_for_file: INVALID_USE_OF_PROTECTED_MEMBER
 // ignore_for_file: INVALID_USE_OF_VISIBLE_FOR_TESTING_MEMBER

--- a/lib/refresh/pull_to_refresh/src/smart_refresher.dart
+++ b/lib/refresh/pull_to_refresh/src/smart_refresher.dart
@@ -436,7 +436,7 @@ class SmartRefresherState extends State<SmartRefresher> {
         dragStartBehavior: dragStartBehavior ?? DragStartBehavior.start,
         reverse: reverse ?? false,
       );
-    } else if (childView is Scrollable) {
+    } else /*if (childView is Scrollable)*/ {
       body = Scrollable(
         physics: _getScrollPhysics(
             conf, childView.physics ?? AlwaysScrollableScrollPhysics()),

--- a/lib/scroll/scroll_bar_style.dart
+++ b/lib/scroll/scroll_bar_style.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -141,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: horizontal_data_table
 description: A horizontal data table with a fixed column on left handside.
-version: 3.6.1+1
+version: 3.6.2
 author: May Lau<may.lau.dev@gmail.com>
 homepage: https://github.com/MayLau-CbL/flutter_horizontal_data_table
 


### PR DESCRIPTION
This PR updated:
-updated example android project for 2.10.5 flutter version
-removed unnecessary import of pull to refresh
-fixed minor comment typo